### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Resolve hex colors shorthand.",
   "license": "MIT",
-  "repository": "username/repository",
+  "repository": "filipelinhares/hex-color-resolve",
   "author": "Filipe <filipelinhares.com>",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Let's update the "repository" field properly in the package.json because npmjs.com doesn't link to GitHub repo otherwise.